### PR TITLE
Define maintainers and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@ChristophWurst

--- a/README.md
+++ b/README.md
@@ -12,5 +12,10 @@ enabled 2FA provider.
 
 For more details, see the [admin documentation] and [user documentation].
 
+## Maintainers
+
+* [ChristophWurst](https://github.com/ChristophWurst)
+* [Nextcloud Two-Factor Authentication Working Group](https://github.com/nextcloud/wg-two-factor-authentication#members)
+
 [admin documentation]: https://nextcloud-twofactor-admin.readthedocs.io/en/latest/Admin%20Documentation/
 [user documentation]: https://nextcloud-twofactor-admin.readthedocs.io/en/latest/User%20Documentation/

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,6 +12,7 @@
 	<version>3.2.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
+	<author homepage="https://github.com/nextcloud/wg-two-factor-authentication">Nextcloud Two-Factor Authentication Working Group</author>
 	<namespace>TwoFactorAdmin</namespace>
 	<documentation>
 		<user>https://nextcloud-twofactor-admin.readthedocs.io/en/latest/User%20Documentation/</user>


### PR DESCRIPTION
As per our usual pattern I'm setting myself as the main maintainer and the group as a backup.

The explicit ownership should allow automated review requests.

Clear responsibility. Clear ownership :)

Companion PR: https://github.com/nextcloud/wg-two-factor-authentication/pull/7