### PR TITLE
ci: Disable scheduled releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
-on:
-  schedule:
-    - cron: "42 8 * * 1,3,5"
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   release:


### PR DESCRIPTION
Release workflows need to be approved. Let's do them manual only.