### PR TITLE
ci: Fix xmllint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Download schema
         run: wget https://apps.nextcloud.com/schema/apps/info.xsd
       - name: Lint info.xml
-        uses: ChristophWurst/xmllint-action@v1
+        uses: ChristophWurst/xmllint-action@v1.1
         with:
           xml-file: ./appinfo/info.xml
           xml-schema-file: ./info.xsd


### PR DESCRIPTION
Self-hosted runners need v1.1 based on Alpine