### PR TITLE
build(packaging): Fix app packaging with bin plugin

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -24,3 +24,4 @@
 /vendor/bin
 /vendor/christophwurst/nextcloud/.git
 /vendor/endroid/qr-code/assets
+/vendor-bin

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 			"@composer bin all update --ansi"
 		]
 	},
-    "require-dev": {
+    "require": {
         "bamarni/composer-bin-plugin": "^1.8.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f41b95c5a3b2083bdcbf4231daff0c0",
-    "packages": [],
-    "packages-dev": [
+    "content-hash": "70541af1b25d9586e342c34d1967ac79",
+    "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
             "version": "1.8.2",
@@ -65,6 +64,7 @@
             "time": "2022-10-31T08:38:03+00:00"
         }
     ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],


### PR DESCRIPTION
Fixes the packaging regression of https://github.com/nextcloud/twofactor_admin/pull/290

https://github.com/nextcloud/twofactor_admin/actions/runs/6157622314/job/16708724731

This moves the bin plugin to production deps. Same trick we needed for Mail. Bin dependencies are ignored and not packaged.