### PR TITLE
ci: Bump TriPSs/conventional-changelog-action from v3 to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v3
+        uses: TriPSs/conventional-changelog-action@v5
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           skip-git-pull: "true"


### PR DESCRIPTION
For https://github.com/nextcloud/twofactor_admin/issues/361#issuecomment-2437003543

cc @j-nicolas