### PR TITLE
ci: Fix installing custom npm for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ChristophWurst/setup-nextcloud@fc0790385c175d97e88a7cb0933490de6e990374 # v0.3.2
         with:
           php-version: 'false'
-          node-version: 'false'
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
           npm-version: ${{ steps.versions.outputs.npmVersion }}
           tools: 'krankerl'
       - name: Package app


### PR DESCRIPTION
The setup action fails on installing custom npm with the default node installation. With a custom node installation it can install a custom npm.